### PR TITLE
Add new i-shipped entries for recent PRs

### DIFF
--- a/src/content/i-shipped/a-change-to-install-wasm-pack-via-cargo-instead-of-npm.mdx
+++ b/src/content/i-shipped/a-change-to-install-wasm-pack-via-cargo-instead-of-npm.mdx
@@ -1,0 +1,7 @@
+---
+summary: a change to install wasm-pack via cargo instead of npm
+repo: garden-co/jazz
+mergeDate: 2026-03-31
+prNumber: '3515'
+---
+We had been pulling in `wasm-pack` as an npm package, which dragged in `axios` and another helper library as transitive dependencies -- more things to trust from the npm ecosystem. Since anyone building our Rust/WASM crate already has a full Rust toolchain installed anyway, I switched us to installing `wasm-pack` directly via `cargo install`. One less set of supply-chain risks to worry about.

--- a/src/content/i-shipped/a-fix-for-a-better-auth-race-condition.mdx
+++ b/src/content/i-shipped/a-fix-for-a-better-auth-race-condition.mdx
@@ -1,0 +1,7 @@
+---
+summary: a fix for a Better Auth race condition
+repo: garden-co/jazz
+mergeDate: 2026-04-10
+prNumber: '3519'
+---
+When signing in with Better Auth, a slow `/get-session` request could arrive *after* the user had already successfully signed in via a different flow. Because the slow response said "no session", it would log the user straight back out again. I added a little counter that increments each time the user authenticates, and we attach it as a header to session requests -- if a stale response comes back with an old counter value, we now know to ignore it.

--- a/src/content/i-shipped/a-fix-for-a-hang-in-create-jazz-context-when-schema-migrations-fail.mdx
+++ b/src/content/i-shipped/a-fix-for-a-hang-in-create-jazz-context-when-schema-migrations-fail.mdx
@@ -1,0 +1,7 @@
+---
+summary: a fix for a hang in createJazzContext when schema migrations fail
+repo: garden-co/jazz
+mergeDate: 2026-04-10
+prNumber: '3520'
+---
+If your app's migration tried to load a piece of data whose shape didn't match any of the allowed schema variants, Jazz would silently get stuck forever instead of telling you what had gone wrong. The error was being thrown inside an internal loop that swallowed it, so the underlying promise never settled. I added a dedicated error type for this case and caught it in the right place, so loads now fail cleanly as "unavailable" rather than hanging your app.

--- a/src/content/i-shipped/a-fix-for-a-race-condition-in-our-auth-storage-code.mdx
+++ b/src/content/i-shipped/a-fix-for-a-race-condition-in-our-auth-storage-code.mdx
@@ -1,0 +1,7 @@
+---
+summary: a fix for a race condition in our auth storage code
+repo: garden-co/jazz
+mergeDate: 2026-03-19
+prNumber: '3505'
+---
+Jazz stores some authentication secrets behind the scenes, and our `set` function was telling everyone "the new value is ready!" before it had actually finished writing to storage. That tiny window was enough to cause spurious logouts when another part of the app asked for the session at the wrong moment. I added a missing `await` so the write finishes before anyone else is notified.

--- a/src/content/i-shipped/a-fix-for-invalid-signature-errors-when-concurrent-writes-happen.mdx
+++ b/src/content/i-shipped/a-fix-for-invalid-signature-errors-when-concurrent-writes-happen.mdx
@@ -1,0 +1,7 @@
+---
+summary: a fix for InvalidSignature errors when concurrent writes happen
+repo: garden-co/jazz
+mergeDate: 2026-03-31
+prNumber: '3514'
+---
+When two writers were updating the same piece of data at the same time, Jazz would sometimes throw an `InvalidSignature` error on load. The cause was a classic off-by-one: our code was using a count where it needed an index, so it was fetching one more transaction than the stored signature actually covered. I changed that one number and the storage layer now copes with concurrent writes properly.

--- a/src/content/i-shipped/a-fix-to-pass-ssh-agent-variables-through-to-the-sandbox.mdx
+++ b/src/content/i-shipped/a-fix-to-pass-ssh-agent-variables-through-to-the-sandbox.mdx
@@ -1,0 +1,7 @@
+---
+summary: a fix to pass SSH agent variables through to the sandbox
+repo: mksglu/context-mode
+mergeDate: 2026-03-03
+prNumber: '29'
+---
+When running commands like `git fetch` inside the sandbox, they couldn't talk to my running SSH agent because the relevant environment variables were being stripped out. That meant SSH would pop up and ask for my passphrase on the terminal, which garbled the Claude Code session I was working in. I added `SSH_AUTH_SOCK` and `SSH_AGENT_PID` to the list of variables that get passed through, so SSH "just works" inside the sandbox.

--- a/src/content/i-shipped/a-typo-fix-in-the-tiptap-svelte-installation-guide.mdx
+++ b/src/content/i-shipped/a-typo-fix-in-the-tiptap-svelte-installation-guide.mdx
@@ -1,0 +1,7 @@
+---
+summary: a typo fix in the Tiptap Svelte installation guide
+repo: ueberdosis/tiptap-docs
+mergeDate: 2026-03-09
+prNumber: '653'
+---
+Small but satisfying: I spotted a one-character typo in the Svelte installation instructions on the Tiptap docs site and sent in a fix.

--- a/src/content/i-shipped/a-unified-signature-for-create-invite-link-across-core-and-browser.mdx
+++ b/src/content/i-shipped/a-unified-signature-for-create-invite-link-across-core-and-browser.mdx
@@ -1,0 +1,7 @@
+---
+summary: a unified signature for createInviteLink across core and browser
+repo: garden-co/jazz
+mergeDate: 2026-04-01
+prNumber: '3507'
+---
+Our `createInviteLink` function had two different shapes depending on whether you imported it from the core library or from the browser/React Native wrappers. That was confusing for users and, in particular, was causing AI coding assistants to generate broken code because they'd mix up the two forms. I added an options-object overload to the core version so it matches the browser version, and cleaned up some duplicate implementations along the way. The old positional form still works, but it's now deprecated.

--- a/src/content/i-shipped/four-bug-fixes-for-my-chicken-dinner-timer-app.mdx
+++ b/src/content/i-shipped/four-bug-fixes-for-my-chicken-dinner-timer-app.mdx
@@ -1,0 +1,7 @@
+---
+summary: four bug fixes for my Chicken Dinner Timer app
+repo: joeinnes/chicken-dinner-timer
+mergeDate: 2026-02-22
+prNumber: '2'
+---
+I went back to my old Chicken Dinner Timer app and fixed a handful of small bugs I'd been meaning to sort out. I corrected an invalid input type, zero-padded the start time so the browser's time picker would actually bind to it, made the timeline entries sort by number instead of alphabetically, and fixed an `addTime` function that was ignoring the value it was given in favour of a stale closure variable.


### PR DESCRIPTION
## Summary
- Adds 9 new i-shipped entries covering recent merged PRs
- garden-co/jazz: #3505, #3507, #3514, #3515, #3519, #3520
- Plus ueberdosis/tiptap-docs #653, mksglu/context-mode #29, joeinnes/chicken-dinner-timer #2

## Test plan
- [ ] Verify entries render correctly on `/i-shipped`
- [ ] Confirm frontmatter validates against the content collection schema

https://claude.ai/code/session_01T4HTQy5fbctsFWUXQh6vHk