### PR TITLE
Add 55 new i-shipped entries for garden-co/jazz2

### DIFF
--- a/src/content/i-shipped/a-built-in-mcp-docs-server-for-jazz-tools.mdx
+++ b/src/content/i-shipped/a-built-in-mcp-docs-server-for-jazz-tools.mdx
@@ -1,0 +1,7 @@
+---
+summary: a built-in MCP docs server for jazz-tools
+repo: garden-co/jazz2
+mergeDate: 2026-03-05
+prNumber: '211'
+---
+I built an MCP server into jazz-tools that exposes Jazz documentation as searchable tools for AI assistants. You can run it with `npx jazz-tools mcp` and it gives AI coding assistants direct access to the Jazz docs.

--- a/src/content/i-shipped/a-change-to-install-wasm-pack-via-cargo-in-jazz2.mdx
+++ b/src/content/i-shipped/a-change-to-install-wasm-pack-via-cargo-in-jazz2.mdx
@@ -1,0 +1,7 @@
+---
+summary: a change to install wasm-pack via cargo in jazz2
+repo: garden-co/jazz2
+mergeDate: 2026-03-31
+prNumber: '427'
+---
+I removed the npm wasm-pack package and switched to installing it via cargo instead. This eliminates the axios transitive dependency, reducing the risk of supply chain vulnerabilities.

--- a/src/content/i-shipped/a-dedicated-docs-section-for-read-durability-tiers.mdx
+++ b/src/content/i-shipped/a-dedicated-docs-section-for-read-durability-tiers.mdx
@@ -1,0 +1,7 @@
+---
+summary: a dedicated docs section for read durability tiers
+repo: garden-co/jazz2
+mergeDate: 2026-04-14
+prNumber: '504'
+---
+I promoted read durability from a footnote to its own top-level section on the reading/queries page, with tier definitions, per-tier guidance, and reference material so developers can choose the right durability level for their use case.

--- a/src/content/i-shipped/a-docs-url-update-in-starter-agentsmd-files.mdx
+++ b/src/content/i-shipped/a-docs-url-update-in-starter-agentsmd-files.mdx
@@ -1,0 +1,7 @@
+---
+summary: a docs URL update in starter AGENTS.md files
+repo: garden-co/jazz2
+mergeDate: 2026-04-22
+prNumber: '636'
+---
+I replaced the temporary `jazz2-docs.vercel.app` URLs with the permanent `jazz.tools` domain across all starter AGENTS.md files.

--- a/src/content/i-shipped/a-fix-for-a-callback-race-condition-in-subscriptions.mdx
+++ b/src/content/i-shipped/a-fix-for-a-callback-race-condition-in-subscriptions.mdx
@@ -1,0 +1,7 @@
+---
+summary: a fix for a callback race condition in subscriptions
+repo: garden-co/jazz2
+mergeDate: 2026-03-05
+prNumber: '210'
+---
+I fixed a race condition where the subscription callback could fire before the internal tracking map was ready. The synchronous `immediate_tick()` call was triggering the callback before the sender could be inserted into the shared subscription map.

--- a/src/content/i-shipped/a-fix-for-corrupted-columns-on-subscription-updates.mdx
+++ b/src/content/i-shipped/a-fix-for-corrupted-columns-on-subscription-updates.mdx
@@ -1,0 +1,7 @@
+---
+summary: a fix for corrupted columns on subscription updates
+repo: garden-co/jazz2
+mergeDate: 2026-03-02
+prNumber: '185'
+---
+I fixed a bug where using `.include()` caused base columns to get corrupted when a subscription fired a second time. The reevaluation function was being passed the output tuple (which included extra joined columns) instead of the original base columns, causing data to shift around.

--- a/src/content/i-shipped/a-fix-for-drop-column-generation-in-multi-table-migrations.mdx
+++ b/src/content/i-shipped/a-fix-for-drop-column-generation-in-multi-table-migrations.mdx
@@ -1,0 +1,7 @@
+---
+summary: a fix for DROP COLUMN generation in multi-table migrations
+repo: garden-co/jazz2
+mergeDate: 2026-03-02
+prNumber: '187'
+---
+I fixed a bug where running a migration on multiple tables at once only generated the DROP COLUMN SQL for the first table, silently skipping the rest.

--- a/src/content/i-shipped/a-fix-for-empty-query-results-from-anonymous-clients.mdx
+++ b/src/content/i-shipped/a-fix-for-empty-query-results-from-anonymous-clients.mdx
@@ -1,0 +1,7 @@
+---
+summary: a fix for empty query results from anonymous clients
+repo: garden-co/jazz2
+mergeDate: 2026-03-05
+prNumber: '198'
+---
+I fixed a bug where demo and anonymous clients always got empty query results. They were sending no session in their subscription payloads, and a previous change had made the server require a session for policy evaluation. Now the server falls back to the session it established during the connection handshake.

--- a/src/content/i-shipped/a-fix-for-garbled-query-results-when-using-include.mdx
+++ b/src/content/i-shipped/a-fix-for-garbled-query-results-when-using-include.mdx
@@ -1,0 +1,7 @@
+---
+summary: a fix for garbled query results when using include
+repo: garden-co/jazz2
+mergeDate: 2026-02-23
+prNumber: '107'
+---
+I fixed a bug where using `.include()` on message queries caused the message text to come out garbled. The root cause was that an internal descriptor wasn't being updated after array subqueries were compiled, so the data was being read from the wrong columns.

--- a/src/content/i-shipped/a-fix-for-incorrect-pluralization-in-the-code-generator.mdx
+++ b/src/content/i-shipped/a-fix-for-incorrect-pluralization-in-the-code-generator.mdx
@@ -1,0 +1,7 @@
+---
+summary: a fix for incorrect pluralization in the code generator
+repo: garden-co/jazz2
+mergeDate: 2026-02-23
+prNumber: '105'
+---
+I replaced a hand-rolled singularize function with the pluralize-esm library. The old function only handled a few suffix patterns and got common English plurals wrong — for example, it was turning "canvases" into "Canvase" instead of "Canvas".

--- a/src/content/i-shipped/a-fix-for-missing-policy-enforcement-in-queries.mdx
+++ b/src/content/i-shipped/a-fix-for-missing-policy-enforcement-in-queries.mdx
@@ -1,0 +1,7 @@
+---
+summary: a fix for missing policy enforcement in queries
+repo: garden-co/jazz2
+mergeDate: 2026-02-27
+prNumber: '147'
+---
+I fixed an issue where `query()` and `subscribe()` weren't applying permission policies because the session wasn't being passed through. Now the client defaults to the JWT session resolved at construction time, so policies are always enforced.

--- a/src/content/i-shipped/a-fix-for-policy-evaluation-with-ephemeral-claims.mdx
+++ b/src/content/i-shipped/a-fix-for-policy-evaluation-with-ephemeral-claims.mdx
@@ -1,0 +1,7 @@
+---
+summary: a fix for policy evaluation with ephemeral claims
+repo: garden-co/jazz2
+mergeDate: 2026-03-27
+prNumber: '353'
+---
+I fixed an issue where per-subscription claims sent by the client weren't being merged into the server session. This meant policies that depended on ephemeral claims couldn't evaluate correctly.

--- a/src/content/i-shipped/a-fix-for-svelte-state-referenced-locally-warnings.mdx
+++ b/src/content/i-shipped/a-fix-for-svelte-state-referenced-locally-warnings.mdx
@@ -1,0 +1,7 @@
+---
+summary: a fix for Svelte state_referenced_locally warnings
+repo: garden-co/jazz2
+mergeDate: 2026-04-03
+prNumber: '445'
+---
+I moved prop reads in JazzSvelteProvider and SyntheticUserSwitcher into reactive contexts so the Svelte 5 compiler no longer emits `state_referenced_locally` warnings. I also improved lifecycle handling in both components.

--- a/src/content/i-shipped/a-fix-for-worker-url-resolution-in-bundlers.mdx
+++ b/src/content/i-shipped/a-fix-for-worker-url-resolution-in-bundlers.mdx
@@ -1,0 +1,7 @@
+---
+summary: a fix for worker URL resolution in bundlers
+repo: garden-co/jazz2
+mergeDate: 2026-04-17
+prNumber: '540'
+---
+I switched from dynamic runtime URL resolution to a static `new URL(...)` pattern for the web worker bootstrap. This lets bundlers like Vite, webpack, and Next.js/Turbopack detect and co-bundle the worker and WASM files correctly.

--- a/src/content/i-shipped/a-fix-to-always-run-the-schema-build-on-every-build.mdx
+++ b/src/content/i-shipped/a-fix-to-always-run-the-schema-build-on-every-build.mdx
@@ -1,0 +1,7 @@
+---
+summary: a fix to always run the schema build on every build
+repo: garden-co/jazz2
+mergeDate: 2026-03-12
+prNumber: '312'
+---
+I fixed a bug where the TypeScript schema build step was being skipped after the first run. The CLI was checking if the output file already existed and bailing out, which meant schema changes weren't being picked up on subsequent builds.

--- a/src/content/i-shipped/a-friendlier-api-for-permission-relation-names.mdx
+++ b/src/content/i-shipped/a-friendlier-api-for-permission-relation-names.mdx
@@ -1,0 +1,7 @@
+---
+summary: a friendlier API for permission relation names
+repo: garden-co/jazz2
+mergeDate: 2026-04-08
+prNumber: '476'
+---
+I updated `allowedTo` so you can write `allowedTo.read("project")` instead of having to specify the full "projectId" suffix. It tries an exact match first, then falls back to adding "Id" or "_id" for backwards compatibility.

--- a/src/content/i-shipped/a-full-chat-example-with-permissions-and-invite-flow.mdx
+++ b/src/content/i-shipped/a-full-chat-example-with-permissions-and-invite-flow.mdx
@@ -1,0 +1,7 @@
+---
+summary: a full chat example with permissions and invite flow
+repo: garden-co/jazz2
+mergeDate: 2026-03-20
+prNumber: '313'
+---
+I built a complete React chat example app for Jazz featuring messaging, reactions, a canvas, file uploads, and row-level permissions with an invite flow. It shows how to build a real collaborative app with proper access control.

--- a/src/content/i-shipped/a-module-type-declaration-fix-for-the-jazz-wasm-package.mdx
+++ b/src/content/i-shipped/a-module-type-declaration-fix-for-the-jazz-wasm-package.mdx
@@ -1,0 +1,8 @@
+---
+summary: >-
+  a module type declaration fix for the jazz-wasm package
+repo: garden-co/jazz2
+mergeDate: 2026-04-17
+prNumber: '543'
+---
+I added `"type": "module"` to the jazz-wasm package.json. Without it, running the CLI via npx or bunx would fail with an ERR_REQUIRE_CYCLE_MODULE error because Node.js was treating the ES module output as CommonJS.

--- a/src/content/i-shipped/a-moon-lander-multiplayer-game-example.mdx
+++ b/src/content/i-shipped/a-moon-lander-multiplayer-game-example.mdx
@@ -1,0 +1,7 @@
+---
+summary: a moon lander multiplayer game example
+repo: garden-co/jazz2
+mergeDate: 2026-04-08
+prNumber: '235'
+---
+I built a multiplayer moon lander game as an example app for Jazz using React and Phaser. It demonstrates real-time multiplayer sync — multiple players can fly their landers at the same time and see each other's movements.

--- a/src/content/i-shipped/a-react-quick-start-guide.mdx
+++ b/src/content/i-shipped/a-react-quick-start-guide.mdx
@@ -1,0 +1,7 @@
+---
+summary: a React quick start guide
+repo: garden-co/jazz2
+mergeDate: 2026-02-19
+prNumber: '86'
+---
+I wrote a quickstart guide for React developers getting started with Jazz. It consolidates the main topics into a single reference so new users can get up and running quickly.

--- a/src/content/i-shipped/a-schema-hash-cli-command.mdx
+++ b/src/content/i-shipped/a-schema-hash-cli-command.mdx
@@ -1,0 +1,7 @@
+---
+summary: a schema hash CLI command
+repo: garden-co/jazz2
+mergeDate: 2026-04-22
+prNumber: '616'
+---
+I added a `jazz-tools schema hash` command that prints the short hash of your current schema.ts file locally, without hitting the server or writing a snapshot. Handy for checking if your local schema matches what's deployed.

--- a/src/content/i-shipped/a-sveltekit-vite-plugin-for-jazz.mdx
+++ b/src/content/i-shipped/a-sveltekit-vite-plugin-for-jazz.mdx
@@ -1,0 +1,7 @@
+---
+summary: a SvelteKit Vite plugin for Jazz
+repo: garden-co/jazz2
+mergeDate: 2026-04-15
+prNumber: '522'
+---
+I built a new Vite plugin for SvelteKit projects that manages the Jazz dev-server lifecycle automatically. It supports embedded server mode, connecting to an external URL, or reading the config from environment variables.

--- a/src/content/i-shipped/a-vue-3-example-app-showcasing-jazz.mdx
+++ b/src/content/i-shipped/a-vue-3-example-app-showcasing-jazz.mdx
@@ -1,0 +1,7 @@
+---
+summary: a Vue 3 example app showcasing Jazz
+repo: garden-co/jazz2
+mergeDate: 2026-04-01
+prNumber: '408'
+---
+I built a complete Vue 3 example app demonstrating Jazz as a local-first relational database. It covers schema definitions, permissions, and file handling — everything you need to see how Jazz works with Vue.

--- a/src/content/i-shipped/agentsmd-files-for-jazz-starter-templates.mdx
+++ b/src/content/i-shipped/agentsmd-files-for-jazz-starter-templates.mdx
@@ -1,0 +1,7 @@
+---
+summary: AGENTS.md files for Jazz starter templates
+repo: garden-co/jazz2
+mergeDate: 2026-04-22
+prNumber: '630'
+---
+I added an AGENTS.md file to all nine starter templates, directing AI coding agents to fetch live Jazz documentation rather than relying on their training data. This helps agents give more accurate and up-to-date advice when working in Jazz projects.

--- a/src/content/i-shipped/aligned-vue-and-svelte-bindings-to-match-the-react-api.mdx
+++ b/src/content/i-shipped/aligned-vue-and-svelte-bindings-to-match-the-react-api.mdx
@@ -1,0 +1,7 @@
+---
+summary: aligned Vue and Svelte bindings to match the React API
+repo: garden-co/jazz2
+mergeDate: 2026-03-18
+prNumber: '351'
+---
+I brought the Vue and Svelte bindings up to feature parity with React. Vue's `useAll` now accepts QueryOptions, and the Svelte bindings got a proper SubscriptionsOrchestrator, so all three frameworks have a consistent API.

--- a/src/content/i-shipped/an-advanced-internals-reference-page-for-the-docs.mdx
+++ b/src/content/i-shipped/an-advanced-internals-reference-page-for-the-docs.mdx
@@ -1,0 +1,7 @@
+---
+summary: an advanced internals reference page for the docs
+repo: garden-co/jazz2
+mergeDate: 2026-04-07
+prNumber: '449'
+---
+I wrote a new Advanced Internals page covering the Jazz data model, browser architecture, query engine, sync protocol, schema evolution, and durability signals. I also fixed several documentation gaps along the way.

--- a/src/content/i-shipped/an-interactive-app-id-generation-widget-for-the-docs.mdx
+++ b/src/content/i-shipped/an-interactive-app-id-generation-widget-for-the-docs.mdx
@@ -1,0 +1,7 @@
+---
+summary: an interactive app ID generation widget for the docs
+repo: garden-co/jazz2
+mergeDate: 2026-04-21
+prNumber: '606'
+---
+I added an interactive widget to the quickstart docs that generates an app ID, admin secret, and backend secret from the hosted Jazz Cloud service. It automatically substitutes the generated values into the code examples on the page.

--- a/src/content/i-shipped/assorted-example-app-updates.mdx
+++ b/src/content/i-shipped/assorted-example-app-updates.mdx
@@ -1,0 +1,7 @@
+---
+summary: assorted example app updates
+repo: garden-co/jazz2
+mergeDate: 2026-04-22
+prNumber: '622'
+---
+I migrated several example apps (chat-react, moon-lander-react, wequencer) to use the new `jazzPlugin()` from jazz-tools/dev, switched wequencer to local-first auth, fixed a WebSocket proxy issue, and cleaned up permission configurations.

--- a/src/content/i-shipped/corrected-docstrings-for-database-operations.mdx
+++ b/src/content/i-shipped/corrected-docstrings-for-database-operations.mdx
@@ -1,0 +1,7 @@
+---
+summary: corrected docstrings for database operations
+repo: garden-co/jazz2
+mergeDate: 2026-03-05
+prNumber: '201'
+---
+I fixed incorrect docstrings in the database module that described `insert`, `update`, and `deleteFrom` as synchronous when they're actually async. Small fix, but wrong docs can mislead developers.

--- a/src/content/i-shipped/deploy-time-warnings-for-missing-permission-policies.mdx
+++ b/src/content/i-shipped/deploy-time-warnings-for-missing-permission-policies.mdx
@@ -1,0 +1,7 @@
+---
+summary: deploy-time warnings for missing permission policies
+repo: garden-co/jazz2
+mergeDate: 2026-04-21
+prNumber: '603'
+---
+I added schema validation warnings to `jazz-tools deploy` that flag tables without explicit permission policies. The warnings are informational only and don't block the deploy, but they help catch accidental permission gaps before they reach production.

--- a/src/content/i-shipped/ephemeral-storage-fallback-for-firefox-private-browsing.mdx
+++ b/src/content/i-shipped/ephemeral-storage-fallback-for-firefox-private-browsing.mdx
@@ -1,0 +1,7 @@
+---
+summary: ephemeral storage fallback for Firefox private browsing
+repo: garden-co/jazz2
+mergeDate: 2026-04-21
+prNumber: '605'
+---
+I added a fallback so Jazz apps work in Firefox private browsing mode. When the browser blocks access to the Origin Private File System (OPFS) with a SecurityError, the app now transparently falls back to in-memory storage instead of crashing.

--- a/src/content/i-shipped/example-app-alignment-with-docs-and-permission-fixes.mdx
+++ b/src/content/i-shipped/example-app-alignment-with-docs-and-permission-fixes.mdx
@@ -1,0 +1,7 @@
+---
+summary: example app alignment with docs and permission fixes
+repo: garden-co/jazz2
+mergeDate: 2026-04-03
+prNumber: '451'
+---
+I standardised snake_case field naming across all todo and file-upload examples to match the docs convention, added missing permissions.ts files, fixed a bug in wequencer's instrument seeding, and cleaned up undocumented config.

--- a/src/content/i-shipped/exists-subquery-support-in-policy-expressions.mdx
+++ b/src/content/i-shipped/exists-subquery-support-in-policy-expressions.mdx
@@ -1,0 +1,7 @@
+---
+summary: EXISTS subquery support in policy expressions
+repo: garden-co/jazz2
+mergeDate: 2026-03-05
+prNumber: '207'
+---
+I added support for `EXISTS (SELECT FROM ...)` subqueries in the SQL policy expression parser, and fixed a bug where the outer row's ID wasn't being resolved correctly in policy conditions. This lets you write more expressive permission rules.

--- a/src/content/i-shipped/file-and-blob-storage-for-the-wequencer-example.mdx
+++ b/src/content/i-shipped/file-and-blob-storage-for-the-wequencer-example.mdx
@@ -1,0 +1,7 @@
+---
+summary: file and blob storage for the Wequencer example
+repo: garden-co/jazz2
+mergeDate: 2026-04-01
+prNumber: '355'
+---
+I migrated the Wequencer example app from storing sound data as inline bytes to using Jazz's proper file/blob storage pattern with `createFileFromBlob`. This is the recommended way to handle binary data in Jazz.

--- a/src/content/i-shipped/from-implementations-and-a-row-input-macro.mdx
+++ b/src/content/i-shipped/from-implementations-and-a-row-input-macro.mdx
@@ -1,0 +1,7 @@
+---
+summary: From implementations and a row_input! macro
+repo: garden-co/jazz2
+mergeDate: 2026-04-08
+prNumber: '475'
+---
+I added `From<T>` implementations on the `Value` type for common Rust types and introduced a `row_input!` macro for building HashMaps more ergonomically. This deleted about 250 lines of boilerplate across the codebase.

--- a/src/content/i-shipped/granular-reactivity-for-svelte-and-vue.mdx
+++ b/src/content/i-shipped/granular-reactivity-for-svelte-and-vue.mdx
@@ -1,0 +1,7 @@
+---
+summary: granular reactivity for Svelte and Vue
+repo: garden-co/jazz2
+mergeDate: 2026-03-27
+prNumber: '393'
+---
+I added a `reconcileArray` utility that diffs keyed arrays in place and wired it into the Svelte and Vue `onDelta` callbacks. This means only the items that actually changed get re-rendered, instead of the whole list.

--- a/src/content/i-shipped/guides-quickstarts-and-framework-patterns-for-the-docs.mdx
+++ b/src/content/i-shipped/guides-quickstarts-and-framework-patterns-for-the-docs.mdx
@@ -1,0 +1,7 @@
+---
+summary: guides, quickstarts, and framework patterns for the docs
+repo: garden-co/jazz2
+mergeDate: 2026-03-07
+prNumber: '236'
+---
+I added a new guides section to the Jazz docs with quickstart guides for Vue and TypeScript, framework patterns with React/Vue/Svelte tabs, binary data handling, and a WHERE operator reference.

--- a/src/content/i-shipped/jwks-rotation-support-for-self-hosted-servers.mdx
+++ b/src/content/i-shipped/jwks-rotation-support-for-self-hosted-servers.mdx
@@ -1,0 +1,7 @@
+---
+summary: JWKS rotation support for self-hosted servers
+repo: garden-co/jazz2
+mergeDate: 2026-03-20
+prNumber: '340'
+---
+I added JWKS (JSON Web Key Set) rotation support for self-hosted Jazz servers with a TTL-based cache, on-demand refresh, and a stale-if-error fallback. This means the server can automatically pick up new signing keys without needing a restart.

--- a/src/content/i-shipped/migration-of-example-code-to-row-input-macro.mdx
+++ b/src/content/i-shipped/migration-of-example-code-to-row-input-macro.mdx
@@ -1,0 +1,7 @@
+---
+summary: migration of example code to row_input! macro
+repo: garden-co/jazz2
+mergeDate: 2026-04-08
+prNumber: '485'
+---
+I migrated the three remaining hand-rolled HashMap call sites in the examples to use the new `row_input!` macro, and enabled SQLite for persistent storage in the todo-server tests.

--- a/src/content/i-shipped/options-object-support-for-svelte-querysubscription.mdx
+++ b/src/content/i-shipped/options-object-support-for-svelte-querysubscription.mdx
@@ -1,0 +1,7 @@
+---
+summary: options object support for Svelte QuerySubscription
+repo: garden-co/jazz2
+mergeDate: 2026-03-07
+prNumber: '231'
+---
+I updated the Svelte QuerySubscription to accept an options object as its second argument instead of just a bare string. This brings it in line with the React API and makes it easier to pass configuration like the durability tier setting.

--- a/src/content/i-shipped/ordered-transport-batching-for-sync.mdx
+++ b/src/content/i-shipped/ordered-transport-batching-for-sync.mdx
@@ -1,0 +1,7 @@
+---
+summary: ordered transport batching for sync
+repo: garden-co/jazz2
+mergeDate: 2026-03-12
+prNumber: '284'
+---
+I implemented batching for the sync protocol's wire format. Instead of sending one payload per HTTP request, the client now accumulates payloads and flushes them as a single batched POST. This reduces the number of network round-trips and improves sync performance.

--- a/src/content/i-shipped/passphrase-and-passkey-backup-restore-ui-for-starters.mdx
+++ b/src/content/i-shipped/passphrase-and-passkey-backup-restore-ui-for-starters.mdx
@@ -1,0 +1,7 @@
+---
+summary: passphrase and passkey backup/restore UI for starters
+repo: garden-co/jazz2
+mergeDate: 2026-04-20
+prNumber: '584'
+---
+I added an AuthBackup component to four local-first starter templates with recovery phrase and passkey backup/restore support. This gives users a way to recover their account if they lose their device.

--- a/src/content/i-shipped/pruned-tests-in-the-moon-lander-example.mdx
+++ b/src/content/i-shipped/pruned-tests-in-the-moon-lander-example.mdx
@@ -1,0 +1,7 @@
+---
+summary: pruned tests in the moon-lander example
+repo: garden-co/jazz2
+mergeDate: 2026-04-17
+prNumber: '545'
+---
+I deleted 6 test files (about 2,450 lines) from the moon-lander-react example that weren't actually exercising Jazz's sync capabilities. I kept the 4 genuine cross-client sync tests that test what the example is really about.

--- a/src/content/i-shipped/react-spa-starter-variants-and-create-jazz-provisioning.mdx
+++ b/src/content/i-shipped/react-spa-starter-variants-and-create-jazz-provisioning.mdx
@@ -1,0 +1,7 @@
+---
+summary: React SPA starter variants and create-jazz provisioning
+repo: garden-co/jazz2
+mergeDate: 2026-04-21
+prNumber: '592'
+---
+I added three plain-Vite React starters alongside the existing Next.js/SvelteKit ones, and moved the Jazz Cloud provisioning step into the `create-jazz` CLI itself with a `--hosting` flag so you can set up hosting during scaffolding.

--- a/src/content/i-shipped/real-urls-for-placeholder-links-in-a-blog-post.mdx
+++ b/src/content/i-shipped/real-urls-for-placeholder-links-in-a-blog-post.mdx
@@ -1,0 +1,7 @@
+---
+summary: real URLs for placeholder links in a blog post
+repo: garden-co/jazz2
+mergeDate: 2026-04-22
+prNumber: '651'
+---
+I replaced two placeholder texts in the "What is Jazz?" blog post with proper markdown links — one pointing to the Discord community and one to the booking calendar.

--- a/src/content/i-shipped/reliable-end-to-end-test-setup-for-svelte.mdx
+++ b/src/content/i-shipped/reliable-end-to-end-test-setup-for-svelte.mdx
@@ -1,0 +1,7 @@
+---
+summary: reliable end-to-end test setup for Svelte
+repo: garden-co/jazz2
+mergeDate: 2026-03-02
+prNumber: '186'
+---
+I replaced a hand-rolled binary spawn in the Svelte end-to-end test setup with the official `startLocalJazzServer` helper, giving each test run its own port. This made the tests more reliable and less prone to port conflicts.

--- a/src/content/i-shipped/rune-based-test-infrastructure-for-svelte.mdx
+++ b/src/content/i-shipped/rune-based-test-infrastructure-for-svelte.mdx
@@ -1,0 +1,7 @@
+---
+summary: rune-based test infrastructure for Svelte
+repo: garden-co/jazz2
+mergeDate: 2026-03-26
+prNumber: '387'
+---
+I replaced the mock-based Svelte tests with `.svelte.test.ts` files that run through the Svelte compiler. This means the tests exercise real Svelte 5 runes instead of mocking them, so they catch actual bugs in reactive behaviour.

--- a/src/content/i-shipped/rust-examples-for-the-files-and-blobs-docs-page.mdx
+++ b/src/content/i-shipped/rust-examples-for-the-files-and-blobs-docs-page.mdx
@@ -1,0 +1,7 @@
+---
+summary: Rust examples for the files-and-blobs docs page
+repo: garden-co/jazz2
+mergeDate: 2026-04-08
+prNumber: '474'
+---
+I added Rust code tabs (create, load, delete) to the files-and-blobs documentation page, matching the TypeScript/Rust tab pattern used across the rest of the docs.

--- a/src/content/i-shipped/support-for-real-float-column-types.mdx
+++ b/src/content/i-shipped/support-for-real-float-column-types.mdx
@@ -1,0 +1,7 @@
+---
+summary: support for Real (float) column types
+repo: garden-co/jazz2
+mergeDate: 2026-02-25
+prNumber: '118'
+---
+I added support for floating-point columns in the database. The TypeScript side already allowed `col.float()` and generated the right SQL, but the Rust SQL parser was rejecting it with an "UnsupportedType" error.

--- a/src/content/i-shipped/svelte-5-bindings-for-jazz-tools.mdx
+++ b/src/content/i-shipped/svelte-5-bindings-for-jazz-tools.mdx
@@ -1,0 +1,7 @@
+---
+summary: Svelte 5 bindings for jazz-tools
+repo: garden-co/jazz2
+mergeDate: 2026-02-26
+prNumber: '145'
+---
+I added Svelte 5 bindings for jazz-tools, including a reactive QuerySubscription class, context helpers, a user-switcher component, and a hook for linking external identities. This lets Svelte developers use Jazz with idiomatic Svelte 5 rune-based reactivity.

--- a/src/content/i-shipped/test-failure-guidance-for-ai-agents.mdx
+++ b/src/content/i-shipped/test-failure-guidance-for-ai-agents.mdx
@@ -1,0 +1,7 @@
+---
+summary: test failure guidance for AI agents in CLAUDE.md
+repo: garden-co/jazz2
+mergeDate: 2026-04-22
+prNumber: '627'
+---
+I added instructions to the project's CLAUDE.md telling AI coding agents to investigate unexpected test failures rather than assuming they're pre-existing, and to never rewrite tests without asking the developer first.

--- a/src/content/i-shipped/the-create-jazz-cli-scaffolder.mdx
+++ b/src/content/i-shipped/the-create-jazz-cli-scaffolder.mdx
@@ -1,0 +1,7 @@
+---
+summary: the create-jazz CLI scaffolder
+repo: garden-co/jazz2
+mergeDate: 2026-04-20
+prNumber: '524'
+---
+I built an interactive CLI scaffolder so you can run `npm create jazz` to bootstrap a new project. It prompts for your framework choice and auth mode, then fetches the right starter template, resolves dependencies, and initialises git.

--- a/src/content/i-shipped/updated-dev-docs-reflecting-the-build-less-workflow.mdx
+++ b/src/content/i-shipped/updated-dev-docs-reflecting-the-build-less-workflow.mdx
@@ -1,0 +1,7 @@
+---
+summary: updated dev docs reflecting the build-less workflow
+repo: garden-co/jazz2
+mergeDate: 2026-04-01
+prNumber: '441'
+---
+I updated the developer documentation to reflect the current build-less status quo, adding sections on the project layout (schema.ts, permissions.ts, migrations), the defineApp pattern, and type helpers.

--- a/src/content/i-shipped/vite-config-hooks-for-worker-format-and-optimizedeps.mdx
+++ b/src/content/i-shipped/vite-config-hooks-for-worker-format-and-optimizedeps.mdx
@@ -1,0 +1,7 @@
+---
+summary: Vite config hooks for worker format and optimizeDeps
+repo: garden-co/jazz2
+mergeDate: 2026-04-22
+prNumber: '632'
+---
+I updated the Jazz Vite plugins to automatically inject `worker.format: "es"` and `optimizeDeps.exclude: ["jazz-wasm"]` via a config hook. This removes the need for developers to add these settings manually to their Vite config.

--- a/src/content/i-shipped/wequencer-a-collaborative-real-time-music-sequencer-example.mdx
+++ b/src/content/i-shipped/wequencer-a-collaborative-real-time-music-sequencer-example.mdx
@@ -1,0 +1,8 @@
+---
+summary: >-
+  Wequencer, a collaborative real-time music sequencer example
+repo: garden-co/jazz2
+mergeDate: 2026-03-02
+prNumber: '190'
+---
+I built Wequencer — a collaborative real-time music sequencer — as a new example app for Jazz. It's built with Svelte 5 and Tone.js, and lets multiple users compose music together in real time.


### PR DESCRIPTION
Adds 55 i-shipped entries covering merged PRs #86–#651 in garden-co/jazz2 (Feb 19 – Apr 22, 2026).

---
_Generated by [Claude Code](https://claude.ai/code/session_016nHP7qgPTcfkAdxnb6hJRD)_